### PR TITLE
Add GOTO-South configuration files

### DIFF
--- a/goto3.json
+++ b/goto3.json
@@ -1,0 +1,50 @@
+	{
+  "name": "goto3_domealert_daemon",
+  "ip": "10.0.0.30",
+  "port": 9008,
+  "sensor_poll_rate": 1,
+  "sensor_timeout": 5,
+  "sensor_median_samples": 5,
+  "rj11": [
+    {
+      "id": "internal_temp",
+      "label": "Internal Temp",
+      "units": "\u00B0C",
+      "device": "26-00000278b0e6",
+      "type": "tht"
+    },
+    {
+      "id": "internal_humidity",
+      "label": "Internal Hum.",
+      "units": "%RH",
+      "device": "26-00000278b0e6",
+      "type": "thh"
+    }
+  ],
+  "switches": [
+    {
+      "id": "north_shutter_open",
+      "label": "North Shutter",
+      "values": ["NOT FULL OPEN", "FULL OPEN"],
+      "channel": 0
+    },
+    {
+      "id": "south_shutter_open",
+      "label": "South Shutter",
+      "values": ["NOT FULL OPEN", "FULL OPEN"],
+      "channel": 1
+    },
+    {
+      "id": "shutters_closed",
+      "label": "Shutters Closed",
+      "values": ["NOT CLOSED", "CLOSED"],
+      "channel": 2
+    },
+    {
+      "id": "hatch_closed",
+      "label": "Hatch",
+      "values": ["OPEN", "CLOSED"],
+      "channel": 3
+    }
+  ]
+}

--- a/goto4.json
+++ b/goto4.json
@@ -1,0 +1,50 @@
+	{
+  "name": "goto4_domealert_daemon",
+  "ip": "10.0.0.80",
+  "port": 9008,
+  "sensor_poll_rate": 1,
+  "sensor_timeout": 5,
+  "sensor_median_samples": 5,
+  "rj11": [
+    {
+      "id": "internal_temp",
+      "label": "Internal Temp",
+      "units": "\u00B0C",
+      "device": "26-000002791c40",
+      "type": "tht"
+    },
+    {
+      "id": "internal_humidity",
+      "label": "Internal Hum.",
+      "units": "%RH",
+      "device": "26-000002791c40",
+      "type": "thh"
+    }
+  ],
+  "switches": [
+    {
+      "id": "north_shutter_open",
+      "label": "North Shutter",
+      "values": ["NOT FULL OPEN", "FULL OPEN"],
+      "channel": 0
+    },
+    {
+      "id": "south_shutter_open",
+      "label": "South Shutter",
+      "values": ["NOT FULL OPEN", "FULL OPEN"],
+      "channel": 1
+    },
+    {
+      "id": "shutters_closed",
+      "label": "Shutters Closed",
+      "values": ["NOT CLOSED", "CLOSED"],
+      "channel": 2
+    },
+    {
+      "id": "hatch_closed",
+      "label": "Hatch",
+      "values": ["OPEN", "CLOSED"],
+      "channel": 3
+    }
+  ]
+}


### PR DESCRIPTION
We have the dome alerts up and running in the two GOTO-South domes, so here are the config files.